### PR TITLE
Replace with `docker exec`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,8 @@ NAME     := rid
 VERSION  := 0.0.1
 REVISION := $(shell git rev-parse --short HEAD)
 
-GO_BUILD_FLAGS   := -v -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\" -extldflags \"-static\""
-GO_TEST_FLAGS    := -v
-GO_CI_TEST_FLAGS := -v -race -coverprofile=coverage.txt -covermode=atomic
+GO_BUILD_FLAGS := -v -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\" -extldflags \"-static\""
+GO_TEST_FLAGS  := -v
 
 PACKAGE_DIRS := $(shell go list ./... 2> /dev/null | grep -v /vendor/)
 SRC_FILES    := $(shell find . -name '*.go' -not -path './vendor/*')
@@ -50,7 +49,15 @@ test: lint
 
 .PHONY: ci-test
 ci-test: lint
-	@go test $(GO_CI_TEST_FLAGS) $(PACKAGE_DIRS)
+	@go test  $(PACKAGE_DIRS)
+	@echo > coverage.txt
+	@for d in $(PACKAGE_DIRS); do \
+		go test -coverprofile=profile.out -covermode=atomic -race -v $$d; \
+		if [ -f profile.out ]; then \
+			cat profile.out >> coverage.txt; \
+			rm profile.out; \
+		fi; \
+	done
 
 .PHONY: release
 release:

--- a/cli.go
+++ b/cli.go
@@ -144,12 +144,17 @@ func (c *CLI) runDockerExec(name string, args ...string) error {
 		return err
 	}
 
-	args = append([]string{
-		"exec",
-		"-it",
-		cid,
-		name,
-	}, args...)
+	dockerArgs := []string{"exec", "-it"}
+	{
+		for _, e := range c.Envs {
+			dockerArgs = append(dockerArgs, "-e", e)
+		}
+
+		dockerArgs = append(dockerArgs, cid)
+	}
+
+	args = append([]string{name}, args...)
+	args = append(dockerArgs, args...)
 
 	return c.run("docker", args...)
 }

--- a/cli.go
+++ b/cli.go
@@ -73,7 +73,7 @@ func (c *CLI) Run() error {
 	}
 
 	if c.RunInContainer {
-		return c.runInContainer(c.Args[0], c.Args[1:]...)
+		return c.runDockerExec(c.Args[0], c.Args[1:]...)
 	}
 
 	return c.run(c.Args[0], c.Args[1:]...)
@@ -116,7 +116,7 @@ func (c *CLI) run(name string, args ...string) error {
 	return cmd.Run()
 }
 
-func (c *CLI) runInContainer(name string, args ...string) error {
+func (c *CLI) runDockerExec(name string, args ...string) error {
 	if err := c.run("docker-compose", "up", "-d", "--remove-orphans"); err != nil {
 		return err
 	}

--- a/cli.go
+++ b/cli.go
@@ -8,6 +8,8 @@ import (
 	"text/template"
 
 	"github.com/k0kubun/pp"
+
+	"github.com/creasty/rid/docker"
 )
 
 const helpTemplate = `Execute commands via docker-compose
@@ -119,13 +121,19 @@ func (c *CLI) runInContainer(name string, args ...string) error {
 		return err
 	}
 
+	cid, err := docker.FindContainerByService(c.Config.ProjectName, c.Config.MainService, 1)
+	if err != nil {
+		return err
+	}
+
 	args = append([]string{
 		"exec",
-		c.Config.MainService,
+		"-it",
+		cid,
 		name,
 	}, args...)
 
-	return c.run("docker-compose", args...)
+	return c.run("docker", args...)
 }
 
 // ExecVersion prints version info

--- a/cli.go
+++ b/cli.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"text/template"
 
 	"github.com/k0kubun/pp"
@@ -35,6 +36,7 @@ type CLI struct {
 	Context        *Context
 	Config         *Config
 	Args           []string
+	Envs           []string
 	RunInContainer bool
 
 	Stdin  io.Reader
@@ -48,6 +50,7 @@ func NewCLI(ctx *Context, cfg *Config, args []string) *CLI {
 		Context:        ctx,
 		Config:         cfg,
 		Args:           args[1:],
+		Envs:           make([]string, 0),
 		RunInContainer: true,
 
 		Stdin:  os.Stdin,
@@ -59,6 +62,7 @@ func NewCLI(ctx *Context, cfg *Config, args []string) *CLI {
 // Run executes commands
 func (c *CLI) Run() error {
 	c.setup()
+	c.parseEnvs()
 	c.substituteCommand()
 
 	switch c.Args[0] {
@@ -82,6 +86,20 @@ func (c *CLI) Run() error {
 func (c *CLI) setup() {
 	os.Setenv("COMPOSE_PROJECT_NAME", c.Config.ProjectName)
 	os.Setenv("DOCKER_HOST_IP", c.Context.IP)
+}
+
+func (c *CLI) parseEnvs() {
+	i := 0
+	for _, a := range c.Args {
+		if strings.Contains(a, "=") {
+			c.Envs = append(c.Envs, a)
+		} else {
+			break
+		}
+		i++
+	}
+
+	c.Args = c.Args[i:]
 }
 
 func (c *CLI) substituteCommand() {

--- a/cli_test.go
+++ b/cli_test.go
@@ -54,6 +54,40 @@ func TestCLI_setup(t *testing.T) {
 	}
 }
 
+func TestCLI_parseEnvs(t *testing.T) {
+	cli := NewCLI(&Context{}, &Config{}, []string{"rid"})
+
+	t.Run("no envs", func(t *testing.T) {
+		cli.Args = []string{"foo", "bar"}
+		cli.parseEnvs()
+
+		if !reflect.DeepEqual(cli.Args, []string{"foo", "bar"}) {
+			t.Error("it should not alternate args")
+		}
+	})
+
+	t.Run("envs after command", func(t *testing.T) {
+		cli.Args = []string{"foo", "bar", "AAA=123"}
+		cli.parseEnvs()
+
+		if !reflect.DeepEqual(cli.Args, []string{"foo", "bar", "AAA=123"}) {
+			t.Error("it should not alternate args")
+		}
+	})
+
+	t.Run("envs before command", func(t *testing.T) {
+		cli.Args = []string{"AAA=123", "BBB=456", "foo", "bar"}
+		cli.parseEnvs()
+
+		if !reflect.DeepEqual(cli.Args, []string{"foo", "bar"}) {
+			t.Error("it should omit env args")
+		}
+		if !reflect.DeepEqual(cli.Envs, []string{"AAA=123", "BBB=456"}) {
+			t.Error("it should parse envs")
+		}
+	})
+}
+
 func TestCLI_substituteCommand(t *testing.T) {
 	cli := NewCLI(&Context{
 		Command: map[string]*Command{

--- a/docker/container.go
+++ b/docker/container.go
@@ -1,0 +1,52 @@
+package docker
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+const (
+	dockerInspectFormatter = `{{ .ID }} {{ index .Config.Labels "com.docker.compose.project" }}:{{ index .Config.Labels "com.docker.compose.service" }}:{{ index .Config.Labels "com.docker.compose.container-number" }}`
+)
+
+// FindContainerByService returns a container ID for service
+func FindContainerByService(projectName, service string, num int) (string, error) {
+	projectName = NormalizeProjectName(projectName)
+	composeID := fmt.Sprintf("%s:%s:%d", projectName, service, num)
+
+	psStream := new(bytes.Buffer)
+	psCmd := exec.Command("docker", "ps", "-q")
+	psCmd.Stdout = psStream
+	if err := psCmd.Run(); err != nil {
+		return "", err
+	}
+
+	inspectStream := new(bytes.Buffer)
+	inspectCmd := exec.Command("xargs", "docker", "inspect", "--format", dockerInspectFormatter)
+	inspectCmd.Stdin = psStream
+	inspectCmd.Stdout = inspectStream
+	if err := inspectCmd.Run(); err != nil {
+		return "", err
+	}
+
+	r := bufio.NewReader(inspectStream)
+
+	for {
+		line, _, err := r.ReadLine()
+		if err == io.EOF {
+			break
+		}
+
+		s := strings.SplitN(string(line[:]), " ", 2)
+		containerID, label := s[0], s[1]
+		if label == composeID {
+			return containerID, nil
+		}
+	}
+
+	return "", fmt.Errorf("No container for projectName=%s, service=%s, number=%d", projectName, service, num)
+}

--- a/docker/container.go
+++ b/docker/container.go
@@ -10,7 +10,10 @@ import (
 )
 
 const (
-	dockerInspectFormatter = `{{ .ID }} {{ index .Config.Labels "com.docker.compose.project" }}:{{ index .Config.Labels "com.docker.compose.service" }}:{{ index .Config.Labels "com.docker.compose.container-number" }}`
+	dockerInspectFormatter = `{{ .ID }}` +
+		` {{ index .Config.Labels "com.docker.compose.project" }}` +
+		`:{{ index .Config.Labels "com.docker.compose.service" }}` +
+		`:{{ index .Config.Labels "com.docker.compose.container-number" }}`
 )
 
 // FindContainerByService returns a container ID for service

--- a/docker/util.go
+++ b/docker/util.go
@@ -1,0 +1,18 @@
+package docker
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	// https://github.com/docker/compose/blob/f55c9d42013e8fbb5285bc402d8248a846485217/compose/cli/command.py#L105
+	projectNormalizePattern = regexp.MustCompile(`[^a-z0-9]`)
+)
+
+// NormalizeProjectName normalizes a project name
+func NormalizeProjectName(str string) string {
+	str = strings.ToLower(str)
+	str = projectNormalizePattern.ReplaceAllString(str, "")
+	return str
+}


### PR DESCRIPTION
## Why

To pass env vars easily and intuitively.

And apparently `docker-compose exec` doesn't support `-e` option.
c.f. https://github.com/docker/compose/issues/4551

## What

```
$ rid FOO=123 BAR=456 script/sample XXX=789
↓
$ docker exec -it -e FOO=123 -e BAR=456 $containerid script/sample XXX=789
```