### PR TITLE
Read config from ~/.rid

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -79,6 +79,9 @@ func (c *CLI) Run() error {
 	}
 
 	if c.RunInContainer {
+		if c.Config == nil {
+			return fmt.Errorf("Unable to locate a config file")
+		}
 		return c.runDockerExec(c.Args[0], c.Args[1:]...)
 	}
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -63,7 +63,6 @@ func NewCLI(ctx *project.Context, cfg *project.Config, args []string) *CLI {
 
 // Run executes commands
 func (c *CLI) Run() error {
-	c.setup()
 	c.parseEnvs()
 	c.substituteCommand()
 
@@ -82,6 +81,7 @@ func (c *CLI) Run() error {
 		if c.Config == nil {
 			return fmt.Errorf("Unable to locate a config file")
 		}
+		c.setup()
 		return c.runDockerExec(c.Args[0], c.Args[1:]...)
 	}
 

--- a/main.go
+++ b/main.go
@@ -20,9 +20,12 @@ func main() {
 		exit(err)
 	}
 
-	cfg, err := project.NewConfig(ctx.ConfigFile)
-	if err != nil {
-		exit(err)
+	var cfg *project.Config
+	if ctx.ConfigFile != "" {
+		cfg, err = project.NewConfig(ctx.ConfigFile)
+		if err != nil {
+			exit(err)
+		}
 	}
 
 	c := cli.NewCLI(ctx, cfg, os.Args)

--- a/project/context.go
+++ b/project/context.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -11,9 +12,9 @@ import (
 )
 
 const (
-	globalRidDir   = "~/.rid"
-	configFileName = "rid/config.yml"
-	libexecDirName = "libexec"
+	globalRidDirName = ".rid"
+	configFileName   = "rid/config.yml"
+	libexecDirName   = "libexec"
 )
 
 // Context represents a world where the command is executed
@@ -62,7 +63,11 @@ func (c *Context) findConfigFile(path string) error {
 }
 
 func (c *Context) findSubstitutions() error {
-	globalFiles, globalFileErr := filepath.Glob(filepath.Join(globalRidDir, libexecDirName, "*"))
+	usr, err := user.Current()
+	if err != nil {
+		return err
+	}
+	globalFiles, globalFileErr := filepath.Glob(filepath.Join(usr.HomeDir, globalRidDirName, libexecDirName, "*"))
 	if globalFileErr != nil {
 		return globalFileErr
 	}

--- a/project/context.go
+++ b/project/context.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	globalRidDir   = "~/.rid"
 	configFileName = "rid/config.yml"
 	libexecDirName = "libexec"
 )
@@ -63,10 +64,15 @@ func (c *Context) findConfigFile(path string) error {
 }
 
 func (c *Context) findSubstitutions() error {
-	files, err := filepath.Glob(filepath.Join(c.BaseDir, libexecDirName, "*"))
-	if err != nil {
-		return err
+	globalFiles, globalFileErr := filepath.Glob(filepath.Join(globalRidDir, libexecDirName, "*"))
+	if globalFileErr != nil {
+		return globalFileErr
 	}
+	localFiles, localFileErr := filepath.Glob(filepath.Join(c.BaseDir, libexecDirName, "*"))
+	if localFileErr != nil {
+		return localFileErr
+	}
+	files := append(globalFiles, localFiles...)
 
 	help := make(map[string]string)
 

--- a/project/context.go
+++ b/project/context.go
@@ -35,9 +35,7 @@ func NewContext(path string) (*Context, error) {
 			},
 		},
 	}
-	if err := c.findConfigFile(path); err != nil {
-		return nil, err
-	}
+	c.findConfigFile(path)
 	if err := c.getLocalIP(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Why

we want to use command like `rid pg` or `rid es` anywhere without adding `rid-pg` / `rid-es` to every ripository

## What

to solve that problem, this PR

- enables to read substitution command from `~/.rid/libexec`
- enables to run such rid command (which runs outside of container) without configfile

the problem here is it is hard to write test.
@creasty please take a look?